### PR TITLE
fix: adding platforms to build push job in github workflows

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -65,6 +65,7 @@ jobs:
     - name: Build and push
       uses: docker/build-push-action@v4
       with:
+        platforms: linux/amd64,linux/arm64
         push: ${{ github.event_name != 'pull_request' }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}  


### PR DESCRIPTION
Adds platform to the build-push job in the github workflows, see: https://docs.docker.com/build/ci/github-actions/multi-platform/