### PR TITLE
Allow pre-existing certificate to be specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,15 @@ Before you begin, ensure you have the following installed:
 
 3. **Generate SSL Certificate:**
 
-    Generate an SSL certificate and private key for FTPS if you plan to use secure connections. We do apply a default certficate is the environment variable `SSL_SUBJECT` not provided.
+    Generate an SSL certificate and private key for FTPS if you plan to use secure connections. We do apply a default certficate if the environment variable `SSL_SUBJECT` not provided.
 
     ```bash
     SSL_SUBJECT="/C=IN/O=haravich/CN=freeops.dev"
+    ```
+
+    If you have your own certificate, you can provide it. The file should contain the full certificate chain starting from the leaf and ending with the CA certificate, followed by the private key in PEM format.
+    ```
+    ... -e FTP_PEM=/tmp/tls/ftp.pem -v /tmp/tls:/tmp/tls ...
     ```
 
 4. **Build and Run**:
@@ -74,6 +79,7 @@ Before you begin, ensure you have the following installed:
     | FTP_MODE | `ftp` | (string) `ftp`/`ftps`/`ftps_implicit`/`ftps_tls` |
     | LOG_STDOUT | `YES` | (bool) `YES`/`NO` |
     | SSL_SUBJECT | - | (string) `/C=IN/O=haravich/CN=freeops.dev` |
+    | PEM_FILE | - | (string) `/tmp/tls/ftp.pem` |
 
 ## Access FTP Server:
 

--- a/run-vsftpd.sh
+++ b/run-vsftpd.sh
@@ -12,16 +12,21 @@ PASV_MAX_PORT="${PASV_MAX_PORT:-21110}"
 FTP_MODE="${FTP_MODE:-ftp}"
 LOG_STDOUT="${LOG_STDOUT:-YES}"
 SSL_SUBJECT="${SSL_SUBJECT:-}"
+PEM_FILE="${PEM_FILE:-}"
 
 # GENERATE SELF-SIGNED CERT
-if [ -z "$SSL_SUBJECT" ]; then
-  openssl req -x509 -nodes -days 365 \
-            -newkey rsa:2048 -keyout /etc/vsftpd/vsftpd.pem -out /etc/vsftpd/vsftpd.pem \
-            -subj "/C=IN/O=FTP/CN=ftp.docker.local"
-else 
-  openssl req -x509 -nodes -days 365 \
-            -newkey rsa:2048 -keyout /etc/vsftpd/vsftpd.pem -out /etc/vsftpd/vsftpd.pem \
-            -subj "$SSL_SUBJECT"
+if [ -z "$PEM_FILE" ]; then
+  if [ -z "$SSL_SUBJECT" ]; then
+    openssl req -x509 -nodes -days 365 \
+              -newkey rsa:2048 -keyout /etc/vsftpd/vsftpd.pem -out /etc/vsftpd/vsftpd.pem \
+              -subj "/C=IN/O=FTP/CN=ftp.docker.local"
+  else
+    openssl req -x509 -nodes -days 365 \
+              -newkey rsa:2048 -keyout /etc/vsftpd/vsftpd.pem -out /etc/vsftpd/vsftpd.pem \
+              -subj "$SSL_SUBJECT"
+  fi
+else
+  cp $PEM_FILE /etc/vsftpd/vsftpd.pem
 fi
 
 # Change FTP user's password


### PR DESCRIPTION
For cases in which a self-signed certificate is not adequate, even for simple testing, you can use something like minica or some other simple CA to generate a certificate and then supply it to the container.

I found this example to be very useful for testing an ftp proxy I was working on. The code is written in rust and uses rustls. rustls does not accept self-signed certs for TLS even if you explicitly trust the self-signed cert. These days, it's trivial to create a CA and sign a cert with it. This PR adds the ability to specify a CA file using an environment variable that should point to a path that gets mounted in the container. I updated the README. Another approach would be to modify the code to create a separate CA, but if you are doing testing and want to locally trust a custom CA, being able to create it outside and pass it in is more convenient.